### PR TITLE
Update readme: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ The commercial [Weave Cloud](https://www.weave.works/product/cloud/) agents will
 
 **Automatically deleting services**
 
-Flux won't automatially delete services that are running on the cluster but don't exist in the control repository. While that might seem like a good idea at first, this would not allow Flux to be deployed to to existing clusters, as it would immediately delete all running deployments as soon as installed! Instead, you'll have to manually delete resources after removing them from the control repository.
+Flux won't automatially delete services that are running on the cluster but don't exist in the control repository. While that might seem like a good idea at first, this would not allow Flux to be deployed to existing clusters, as it would immediately delete all running deployments as soon as installed! Instead, you'll have to manually delete resources after removing them from the control repository.
 
 **Custom Resource Definitions**
 


### PR DESCRIPTION
Fix typo: `to to` => `to`