### PR TITLE
Flux says repository is not ready because Flux version is old

### DIFF
--- a/flux/flux-deployment.yaml
+++ b/flux/flux-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         # There are no ":latest" images for flux. Find the most recent
         # release or image version at https://quay.io/weaveworks/flux
         # and replace the tag here.
-        image: fluxcd/flux:1.14.2
+        image: fluxcd/flux:1.19.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:


### PR DESCRIPTION
Fixes #6 

## Motivation

While doing the tutorial, I found that flux couldn't connect to my repository even though my ssh key was set up correctly. I noticed that version of flux is quite old. Upgrading to 1.19.0 resolved the problem and flux was able to download config from my repository

## Approach

Upgraded flux image from 1.14.2 to 1.19.0